### PR TITLE
finalized Win64 & Linux builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 zig-cache/
 zig-out/
 .popping-dikr
+bin/
+build/
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,45 +8,76 @@ set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED True)
 set(CMAKE_BUILD_TYPE Debug)
 
-add_executable(${PROJECT_NAME}
+add_executable(dikr WIN32
     src/dikr.c
-    src/settings.c
 )
+
 include_directories(submodules/Nuklear)
-
-# add_subdirectory(extern)
-# target_link_libraries(${PROJECT_NAME} PUBLIC haikal)
-
-# find_package(cglm CONFIG REQUIRED)
-# target_link_libraries(${PROJECT_NAME} PRIVATE cglm::cglm)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
-    set_target_properties(${PROJECT_NAME} PROPERTIES VS_GLOBAL_VcpkgEnabled true)
+    set_target_properties(dikr PROPERTIES VS_GLOBAL_VcpkgEnabled true)
     find_package(SDL2 CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME}
+    target_link_libraries(dikr
             PRIVATE
             $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
             $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
     )
     find_package(SDL2_ttf CONFIG REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PRIVATE $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)
+    target_link_libraries(dikr PRIVATE $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/scripts/cmake/")
     find_package(SDL2 CONFIG REQUIRED)
     include_directories(${SDL2_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PUBLIC ${SDL2_LIBRARIES})
+    target_link_libraries(dikr PUBLIC ${SDL2_LIBRARIES})
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/scripts/cmake/")
     find_package(SDL2 CONFIG REQUIRED)
     include_directories(${SDL2_INCLUDE_DIRS})
-    target_link_libraries(${PROJECT_NAME} PUBLIC -lm -ldl ${SDL2_LIBRARIES})
+    target_link_libraries(dikr PUBLIC -lm -ldl ${SDL2_LIBRARIES})
 endif()
 
-# add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-#                    COMMAND ${CMAKE_COMMAND} -E copy_directory
-#                    ${CMAKE_SOURCE_DIR}/resource ${CMAKE_CURRENT_BINARY_DIR}/resource)
+add_custom_command(TARGET dikr POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_SOURCE_DIR}/res ${CMAKE_CURRENT_BINARY_DIR}/res)
+
+# settings
+add_executable(settings WIN32
+    src/settings.c
+)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
+    set_target_properties(settings PROPERTIES VS_GLOBAL_VcpkgEnabled true)
+    find_package(SDL2 CONFIG REQUIRED)
+    target_link_libraries(settings
+            PRIVATE
+            $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
+            $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+    )
+    find_package(SDL2_ttf CONFIG REQUIRED)
+    target_link_libraries(settings PRIVATE $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)
+endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/scripts/cmake/")
+    find_package(SDL2 CONFIG REQUIRED)
+    include_directories(${SDL2_INCLUDE_DIRS})
+    target_link_libraries(settings PUBLIC ${SDL2_LIBRARIES})
+endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/scripts/cmake/")
+    find_package(SDL2 CONFIG REQUIRED)
+    include_directories(${SDL2_INCLUDE_DIRS})
+    target_link_libraries(settings PUBLIC -lm -ldl ${SDL2_LIBRARIES})
+endif()
+
+add_custom_command(TARGET settings POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                   ${CMAKE_SOURCE_DIR}/res ${CMAKE_CURRENT_BINARY_DIR}/res)
+

--- a/src/dikr.c
+++ b/src/dikr.c
@@ -1,6 +1,7 @@
 //بسم الله الرحمن الرحيم
 #ifdef _MSC_VER
-#   define SDL_MAIN_HANDLED
+#   undef main
+#   include <windows.h>
 #elif __linux__
 #   include <unistd.h>
 #endif
@@ -9,14 +10,21 @@
 #include <string.h>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
-#include <SDL.h>
-#include <SDL_ttf.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
 
 //no functions by the will of Allah
-
-int main(int argc, char *argv[])
-{
+#ifdef _MSC_VER
+int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
+#else
+int main(int argc, char *argv[]) {
+#endif
     printf("بسم الله الرحمن الرحيم\n");
+
+#if !defined NDEBUG && defined _MSC_VER
+    AllocConsole();
+    freopen("CONOUT$", "w", stdout);
+#endif
 
     int screen_height = 0;
     int screen_width = 0;
@@ -71,10 +79,13 @@ int main(int argc, char *argv[])
     #ifdef __linux__
     {
         char path[256] = "/home/";
-        strcat(path, getlogin());
-        strcat(path, "/.popping-dikr");
-        conf_path[0] = '\0';
-        strcat(conf_path, path);
+        const char *login_str = getlogin();
+        if (login_str != NULL) {
+            strcat(path, login_str);
+            strcat(path, "/.popping-dikr");
+            conf_path[0] = '\0';
+            strcat(conf_path, path);
+        }
     }
     #endif
 
@@ -137,4 +148,3 @@ int main(int argc, char *argv[])
     SDL_Quit();
 
 }
-

--- a/src/dikr.c
+++ b/src/dikr.c
@@ -10,8 +10,10 @@
 #include <string.h>
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_ttf.h>
+
+#ifndef _MSC_VER
+    #undef main
+#endif
 
 //no functions by the will of Allah
 #ifdef _MSC_VER

--- a/src/settings.c
+++ b/src/settings.c
@@ -19,6 +19,10 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 
+#ifndef _MSC_VER
+    #undef main
+#endif
+
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
 #define NK_INCLUDE_STANDARD_VARARGS

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,7 +1,9 @@
 //بسم الله الرحمن الرحيم
-
-#ifdef __unix__
-    #include <unistd.h>
+#ifdef _MSC_VER
+#   undef main
+#   include <windows.h>
+#elif __linux__
+#   include <unistd.h>
 #endif
 
 #include <stdio.h>
@@ -14,9 +16,8 @@
 #include <limits.h>
 #include <time.h>
 
-#include <SDL.h>
-#include <SDL_ttf.h>
-#undef main
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
 
 #define NK_INCLUDE_FIXED_TYPES
 #define NK_INCLUDE_STANDARD_IO
@@ -34,8 +35,17 @@
 #define SUPPORTED_PLATFORM_TO_SCAN_SYSTEM_FONTS
 #endif
 
-int main()
-{
+#ifdef _MSC_VER
+int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
+#else
+int main(int argc, char *argv[]) {
+#endif
+
+#if !defined NDEBUG && defined _MSC_VER
+    AllocConsole();
+    freopen("CONOUT$", "w", stdout);
+#endif
+
     //popping_dikr vars
     int popping_dikr_window_width = 400;
     int popping_dikr_window_height = 100;
@@ -56,14 +66,17 @@ int main()
     struct nk_colorf background_color;
     struct nk_colorf font_color;
 
+    //load settings
     #ifdef __linux__
     {
-        //getting the config path
         char path[256] = "/home/";
-        strcat(path, getlogin());
-        strcat(path, "/.popping-dikr");
-        popping_dikr_conf_path[0] = '\0';
-        strcat(popping_dikr_conf_path, path);
+        const char *login_str = getlogin();
+        if (login_str != NULL) {
+            strcat(path, login_str);
+            strcat(path, "/.popping-dikr");
+            popping_dikr_conf_path[0] = '\0';
+            strcat(popping_dikr_conf_path, path);
+        }
     }
     #endif
 


### PR DESCRIPTION
Added macros to handle different OS requirements.
Fixed Linux NULL dereference on `getlogin()`.
Fixed SDL2 header includes.